### PR TITLE
updating for dict iter items for python2/py3k compatibility

### DIFF
--- a/flask_neo4j.py
+++ b/flask_neo4j.py
@@ -122,7 +122,7 @@ class Neo4j(object):
             self.index = {}
             # add all the indexes as app attributes
             if self._indexes is not None:
-                for i, i_type in self._indexes.iteritems():
+                for i, i_type in iter(self._indexes.items()):
                     log.debug('getting or creating graph index:{0} {1}'.format(
                         i, i_type
                     ))


### PR DESCRIPTION
As of Python 3.0 the dict.iterkeys(), dict.iteritems() and dict.itervalues() methods are no longer supported.