### PR TITLE
Add an explicit way to call bolt port as seen in https://github.com/t…

### DIFF
--- a/flask_neo4j.py
+++ b/flask_neo4j.py
@@ -125,7 +125,11 @@ class Neo4j(object):
                 self.app.config['GRAPH_USER'],
                 self.app.config['GRAPH_PASSWORD']
             )
-            self.graph_db = Graph(host_database)
+            # We test for bolt in connection string, so py2neo can have excplicit bolt parameter
+            if host_database.find('bolt') == 0:
+                self.graph_db = Graph(host_database, bolt=True)
+            else:
+                self.graph_db = Graph(host_database)
         except SocketError as se:
             log.error('SocketError: {0}'.format(se.message))
             if retry:


### PR DESCRIPTION
…echnige/py2neo/issues/605 . It must work on py2neo v2 because it will not call anything else. And in py2neo v3 will add the parameter when the port is used in the connection string.